### PR TITLE
feat: recommending Flow Scanner extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "salesforce.salesforcedx-vscode",
     "redhat.vscode-xml",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "ForceConfigControl.lightningflowscanner"
   ]
 }


### PR DESCRIPTION
I added the VSCode extension to the list of recommended extensions for the project. If a user opens the project in VSCode and is missing the extension, a prompt will propose to install it.